### PR TITLE
Fix variable name in PubSub docs

### DIFF
--- a/docs/Core/PubSub.md
+++ b/docs/Core/PubSub.md
@@ -72,7 +72,7 @@ builder.Services.AddKafka(builder =>
  var consumeResult = consumer.Consume();
  
  // Batch consumption
- var consumeResultd = consumer.ConsumeBatch();
+ var consumeResults = consumer.ConsumeBatch();
 ```
 
 By default, consumers are going to be registered as **Singleton**.


### PR DESCRIPTION
## Summary
- correct variable name in batch consumption code snippet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f666ad968832a92cfb463d8c710df